### PR TITLE
Make ServerSentEvent.makeBuffer public

### DIFF
--- a/Sources/SSEKit/ServerSentEvent.swift
+++ b/Sources/SSEKit/ServerSentEvent.swift
@@ -19,7 +19,7 @@ public struct ServerSentEvent: Equatable, Sendable {
         self.id = id
     }
 
-    internal func makeBuffer(allocator: ByteBufferAllocator) -> ByteBuffer {
+    public func makeBuffer(allocator: ByteBufferAllocator) -> ByteBuffer {
         var string = ""
 
         if let type = type {


### PR DESCRIPTION
There is a good chance server sent events are going to be output using a response body writer and individual events will need written. 

```swift
    router.get("events") { _, _ -> Response in
        return .init(
            status: .ok, headers: [.contentType: "text/event-stream"], body: .init { writer in
                let allocator = ByteBufferAllocator()
                for value in 0..<25 {
                    try await Task.sleep(for: .seconds(1))
                    try await writer.write(ServerSentEvent(data: .init(string: value.description)).makeBuffer(allocator: allocator))
                }
                try await writer.finish(nil)
            }
        )
    }
```